### PR TITLE
LT-5057: filter rfq events by broker id

### DIFF
--- a/src/Lykke.Snow.AuditService/Modules/RabbitMqModule.cs
+++ b/src/Lykke.Snow.AuditService/Modules/RabbitMqModule.cs
@@ -25,6 +25,7 @@ namespace Lykke.Snow.AuditService.Modules
 
             builder.RegisterType<RfqEventSubscriber>()
                 .WithParameter(TypedParameter.From(_auditServiceSettings.Subscribers.RfqEventSubscriber))
+                .WithParameter(TypedParameter.From(_auditServiceSettings.BrokerId))
                 .As<IStartStop>()
                 .SingleInstance();
         }

--- a/src/Lykke.Snow.AuditService/Settings/AuditServiceSettings.cs
+++ b/src/Lykke.Snow.AuditService/Settings/AuditServiceSettings.cs
@@ -15,5 +15,7 @@ namespace Lykke.Snow.AuditService.Settings
         public ClientSettings? AuditServiceClient { get; set; }
         public SubscribersSettings Subscribers { get; set; } = new SubscribersSettings();
         public CsvExportSettings CsvExportSettings { get; set; } = new CsvExportSettings();
+
+        public string BrokerId { get; set; } = string.Empty;
     }
 }

--- a/tests/Lykke.Snow.AuditService.Tests/RfqEventSubscriberTests.cs
+++ b/tests/Lykke.Snow.AuditService.Tests/RfqEventSubscriberTests.cs
@@ -24,7 +24,7 @@ namespace Lykke.Snow.AuditService.Tests
                 new RfqEvent
                 {
                     EventType = RfqEventTypeContract.New,
-                    BrokerId = "Spain",
+                    BrokerId = "Consors",
                     RfqSnapshot = new MarginTrading.Backend.Contracts.Rfq.RfqContract()
                 }
             };
@@ -62,7 +62,7 @@ namespace Lykke.Snow.AuditService.Tests
                 auditEventProcessor = auditEventProcessorArg;
             }
             
-            return new RfqEventSubscriber(auditEventProcessor, mockLoggerFactory.Object, subscriptionSettings, mockLogger.Object, _rfqAuditEventMapper);
+            return new RfqEventSubscriber(auditEventProcessor, mockLoggerFactory.Object, subscriptionSettings, "consors", mockLogger.Object, _rfqAuditEventMapper);
         }
     }
 }


### PR DESCRIPTION
Not sure about events with a different broker id - should we at least log that we received them? I'd assume that we should not log the whole event, as it might create a security issue.

In the current implementation an event with non-matching broker id is silently ignored by the subscriber.